### PR TITLE
Added the ability to configure the lifetime of handlers.

### DIFF
--- a/src/Paramore.Brighter.AspNetCore/AspNetSubscriberRegistry.cs
+++ b/src/Paramore.Brighter.AspNetCore/AspNetSubscriberRegistry.cs
@@ -8,11 +8,13 @@ namespace Paramore.Brighter.AspNetCore
     {
         private readonly IServiceCollection _services;
         private readonly SubscriberRegistry _registry;
+        private readonly ServiceLifetime _lifetime;
 
-        public AspNetSubscriberRegistry(IServiceCollection services)
+        public AspNetSubscriberRegistry(IServiceCollection services, ServiceLifetime lifetime)
         {
             _services = services;
             _registry = new SubscriberRegistry();
+            _lifetime = lifetime;
         }
 
         public IEnumerable<Type> Get<T>() where T : class, IRequest
@@ -24,7 +26,8 @@ namespace Paramore.Brighter.AspNetCore
             where TRequest : class, IRequest
             where TImplementation : class, IHandleRequests<TRequest>
         {
-            _services.AddTransient<TImplementation>();
+            _services.Add(new ServiceDescriptor(
+                typeof(TImplementation), typeof(TImplementation), _lifetime));
             _registry.Register<TRequest, TImplementation>();
         }
 
@@ -32,7 +35,8 @@ namespace Paramore.Brighter.AspNetCore
             where TRequest : class, IRequest
             where TImplementation : class, IHandleRequestsAsync<TRequest>
         {
-            _services.AddTransient<TImplementation>();
+            _services.Add(new ServiceDescriptor(
+                typeof(TImplementation), typeof(TImplementation), _lifetime));
             _registry.RegisterAsync<TRequest, TImplementation>();
         }
 

--- a/src/Paramore.Brighter.AspNetCore/BrighterOptions.cs
+++ b/src/Paramore.Brighter.AspNetCore/BrighterOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Paramore.Brighter.AspNetCore
 {
     public sealed class BrighterOptions
@@ -16,5 +18,10 @@ namespace Paramore.Brighter.AspNetCore
         /// Configures task queues. Set to null to not use task queues.
         /// </summary>
         public MessagingConfiguration MessagingConfiguration { get; set; }
+
+        /// <summary>
+        /// Configures how the services are injected. Defaults to Transient.
+        /// </summary>
+        public ServiceLifetime HandlerLifetime { get; set; } = ServiceLifetime.Transient;
     }
 }

--- a/src/Paramore.Brighter.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Paramore.Brighter.AspNetCore/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Paramore.Brighter.AspNetCore
             var options = new BrighterOptions();
             configure?.Invoke(options);
 
-            var subscriberRegistry = new AspNetSubscriberRegistry(services);
+            var subscriberRegistry = new AspNetSubscriberRegistry(services, options.HandlerLifetime);
             var handlerFactory = new AspNetHandlerFactory(services);
             var handlerConfiguration = new HandlerConfiguration(subscriberRegistry, handlerFactory, handlerFactory);
 


### PR DESCRIPTION
There are instances where the command lifetime should be configurable. When EntityFramework is used the context lifetimes are set to Scope. I added the ability to set the lifetime in the configuration similar to how Darker works. I don't think this is a breaking change as it is defaulted to Transient.